### PR TITLE
Lowers "pressed" threshold when emulating a button via controller joysticks.

### DIFF
--- a/DeltaCore/Emulator Core/EmulatorCore.swift
+++ b/DeltaCore/Emulator Core/EmulatorCore.swift
@@ -360,6 +360,8 @@ extension EmulatorCore: GameControllerReceiver
             return self.mappedInput(for: mappedInput) == input
         })
         
+        let effectiveValue = input.isContinuous ? value : value.rounded()
+        
         if isSustainedInput && !input.isContinuous
         {
             self.reactivateInputsQueue.async {
@@ -375,12 +377,12 @@ extension EmulatorCore: GameControllerReceiver
 
                 self.reactivateInputsDispatchGroup = nil
                 
-                self.deltaCore.emulatorBridge.activateInput(input.intValue!, value: value)
+                self.deltaCore.emulatorBridge.activateInput(input.intValue!, value: effectiveValue)
             }
         }
         else
         {
-            self.deltaCore.emulatorBridge.activateInput(input.intValue!, value: value)
+            self.deltaCore.emulatorBridge.activateInput(input.intValue!, value: effectiveValue)
         }
     }
     


### PR DESCRIPTION
Problem:
When using some external controllers (in my case, an Xbox One S controller), the cDown and cRight mappings did not work during emulation.

As it turns out, when mapping a continuous input (for instance, a joystick) to a discrete input (for instance, a button), a value of `1` is considered pressed, and any value less than 1 is considered not-pressed.

This would be fine in an ideal world, where controllers send a range of [-1, 1] for both the x and y axis. That is what the code expects, and once the joystick is extended _all the way_ to the edge in any direction, it registers an absolute-value of `1`, resulting in a press for whatever button is mapped to that direction.

Annoyingly, my controller actually sends a range of about [-.99, 1], meaning that even when I extend the joystick all the way to some edges, it's about `.01` away from actually registering a click.

Solution:
Apply some rounding to any values being sent to a discrete input. This means that the press will register after a value of `0.5`, which happens when the joystick is moved halfway to the edge.

Possible Future Improvements:
- 0.5 might not be the optimal threshold for registering a press. It's a bit subjective, but something closer to 0.8 might be more comfortable for some players.

- This logic might belong "lower" in the stack -- for instance, in a particular `emulatorBridge.activateInput()` implementation.