### PR TITLE
feature: Optimized Airplay Support

### DIFF
--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -245,6 +245,11 @@ open class GameViewController: UIViewController, GameControllerReceiver
     {
         super.viewDidLayoutSubviews()
         
+        self.calculateGameFrame()
+    }
+    
+    @discardableResult public func calculateGameFrame(returnFrame: Bool = false) -> CGRect?
+    {
         let screenAspectRatio = self.emulatorCore?.preferredRenderingSize ?? CGSize(width: 1, height: 1)
         
         let controllerViewFrame: CGRect
@@ -307,7 +312,11 @@ open class GameViewController: UIViewController, GameControllerReceiver
         self.controllerView.frame = controllerViewFrame
         
         /* Game View */
-        if
+        if returnFrame
+        {
+            return AVMakeRect(aspectRatio: screenAspectRatio, insideRect: availableGameFrame)
+        }
+        else if
             self.airplayWindow == nil,
             let controllerSkin = self.controllerView.controllerSkin,
             let traits = self.controllerView.controllerSkinTraits,
@@ -347,6 +356,8 @@ open class GameViewController: UIViewController, GameControllerReceiver
         }
         
         self.setNeedsUpdateOfHomeIndicatorAutoHidden()
+        
+        return nil
     }
     
     // MARK: - KVO -

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -259,8 +259,16 @@ open class GameViewController: UIViewController, GameControllerReceiver
             // Controller View Hidden:
             // - Controller View should have a height of 0.
             // - Game View should be centered in self.view.
-             
-            (controllerViewFrame, availableGameFrame) = self.view.bounds.divided(atDistance: 0, from: .maxYEdge)
+            
+            if let mirroredScreen = mirroredScreen
+            {
+                availableGameFrame = mirroredScreen.bounds
+                (controllerViewFrame, _) = self.view.bounds.divided(atDistance: 0, from: .maxYEdge)
+            }
+            else
+            {
+                (controllerViewFrame, availableGameFrame) = self.view.bounds.divided(atDistance: 0, from: .maxYEdge)
+            }
             
         case let traits? where traits.orientation == .portrait:
             // Portrait:

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -315,7 +315,17 @@ open class GameViewController: UIViewController, GameControllerReceiver
         }
         else
         {
-            let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatio, insideRect: (mirroredScreen != nil) ? mirroredScreen!.bounds : availableGameFrame)
+            var screenAspectRatioToUse = screenAspectRatio
+            var availableGameFrameToUse = availableGameFrame
+            if let mirroredScreen = mirroredScreen {
+                availableGameFrameToUse = mirroredScreen.bounds
+                if screenAspectRatio.height > screenAspectRatio.width {
+                    // the only VideoFormat where height > width (for now) is melonDS; correct height for non-touch screen
+                    screenAspectRatioToUse = CGSize(width: screenAspectRatio.width, height: screenAspectRatio.height / 2)
+                }
+            }
+            
+            let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatioToUse, insideRect: availableGameFrameToUse)
             self.gameView.frame = gameViewFrame
         }
         

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -647,7 +647,7 @@ private extension GameViewController
 {
     @objc func screenDidConnect()
     {
-        self.setupMirroringIfApplicable()
+        self.enableMirroringIfApplicable()
     }
 
     @objc func screenDidDisconnect()
@@ -658,13 +658,13 @@ private extension GameViewController
     @objc func screenModeDidChange()
     {
         self.disableMirroring()
-        self.setupMirroringIfApplicable()
+        self.enableMirroringIfApplicable()
     }
 }
 
 public extension GameViewController
 {
-    func setupMirroringIfApplicable()
+    func enableMirroringIfApplicable()
     {
         guard UIScreen.screens.count > 1, let externalScreen = UIScreen.screens.last else { return }
         self.mirroredScreen = externalScreen

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -96,9 +96,8 @@ open class GameViewController: UIViewController, GameControllerReceiver
     private var _previousControllerSkin: ControllerSkinProtocol?
     private var _previousControllerSkinTraits: ControllerSkin.Traits?
     
-    // Screen Mirroing
-    public var mirroredWindow: UIWindow?
-    public var mirroredScreen: UIScreen?
+    public var isAirplayEnabled: Bool = false
+    public var airplayWindow: UIWindow?
     
     /// UIViewController
     open override var prefersStatusBarHidden: Bool {
@@ -169,6 +168,8 @@ open class GameViewController: UIViewController, GameControllerReceiver
         
         let tapGestureRecognizer = UITapGestureRecognizer(target: self.controllerView, action: #selector(ControllerView.becomeFirstResponder))
         self.view.addGestureRecognizer(tapGestureRecognizer)
+        
+        self.handleAirplayScreen()
         
         self.prepareForGame()
     }
@@ -301,7 +302,7 @@ open class GameViewController: UIViewController, GameControllerReceiver
         
         /* Game View */
         if
-            mirroredScreen == nil,
+            self.airplayWindow == nil,
             let controllerSkin = self.controllerView.controllerSkin,
             let traits = self.controllerView.controllerSkinTraits,
             let screens = controllerSkin.screens(for: traits),
@@ -317,9 +318,11 @@ open class GameViewController: UIViewController, GameControllerReceiver
         {
             var screenAspectRatioToUse = screenAspectRatio
             var availableGameFrameToUse = availableGameFrame
-            if let mirroredScreen = mirroredScreen {
-                availableGameFrameToUse = mirroredScreen.bounds
-                if screenAspectRatio.height > screenAspectRatio.width {
+            if let airplayWindow = self.airplayWindow
+            {
+                availableGameFrameToUse = airplayWindow.bounds
+                if screenAspectRatio.height > screenAspectRatio.width
+                {
                     // the only VideoFormat where height > width (for now) is melonDS; correct height for non-touch screen
                     screenAspectRatioToUse = CGSize(width: screenAspectRatio.width, height: screenAspectRatio.height / 2)
                 }
@@ -343,7 +346,7 @@ open class GameViewController: UIViewController, GameControllerReceiver
     // MARK: - KVO -
     /// KVO
     open dynamic override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?)
-    {        
+    {
         guard context == &kvoContext else { return super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context) }
 
         // Ensures the value is actually different, or else we might potentially run into an infinite loop if subclasses hide/show controllerView in viewDidLayoutSubviews()
@@ -414,10 +417,10 @@ extension GameViewController
                 let outputFrame = screen.outputFrame.applying(.init(scaleX: self.view.bounds.width, y: self.view.bounds.height))
                 gameView.frame = outputFrame
                 
-                if let mirroredScreen = mirroredScreen
+                if let airplayWindow = self.airplayWindow
                 {
                     let screenAspectRatio = self.emulatorCore?.preferredRenderingSize ?? CGSize(width: 1, height: 1)
-                    let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatio, insideRect: mirroredScreen.bounds)
+                    let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatio, insideRect: airplayWindow.bounds)
                     self.gameView.frame = gameViewFrame
                 }
                 
@@ -553,7 +556,7 @@ private extension GameViewController
     }
 }
 
-// MARK: - Notifications - 
+// MARK: - Notifications -
 private extension GameViewController
 {
     @objc func willResignActive(with notification: Notification)
@@ -616,78 +619,76 @@ private extension GameViewController
     }
 }
 
-//MARK: - Screen Mirroring -
+//MARK: - AirPlay -
 private extension GameViewController
 {
     @objc func screenDidConnect()
     {
-        self.enableMirroringIfApplicable()
+        self.handleAirplayScreen()
     }
 
     @objc func screenDidDisconnect()
     {
-        self.disableMirroring()
+        self.handleAirplayScreen()
     }
     
     @objc func screenModeDidChange()
     {
-        self.disableMirroring()
-        self.enableMirroringIfApplicable()
+        self.handleAirplayScreen()
     }
 }
 
 public extension GameViewController
 {
-    func enableMirroringIfApplicable()
+    func handleAirplayScreen()
     {
-        guard UIScreen.screens.count > 1, let externalScreen = UIScreen.screens.last else { return }
-        self.mirroredScreen = externalScreen
+        // perform teardown first if already AirPlaying and screens are being switched
+        if self.airplayWindow != nil
+        {
+            self.gameView.removeFromSuperview()
+            self.view.insertSubview(self.gameView, belowSubview: self.controllerView)
+            
+            self.airplayWindow = nil
+            
+            self.gameView.setNeedsLayout()
+            self.gameView.layoutIfNeeded()
+            self.view.setNeedsLayout()
+            self.view.layoutIfNeeded()
+        }
         
-        // Find max resolution
+        // now perform setup of AirPlay screen
+        guard
+            self.isAirplayEnabled,
+            UIScreen.screens.count > 1
+        else { return }
+        
+        let secondScreen = UIScreen.screens[1]
+        
+        // find max resolution
         var max = CGSize(width: 0, height: 0)
         var maxScreenMode: UIScreenMode? = nil
-        if let mirroredScreen = mirroredScreen
+        for mode in secondScreen.availableModes
         {
-            for mode in mirroredScreen.availableModes
+            if (maxScreenMode == nil || mode.size.height > max.height || mode.size.width > max.width)
             {
-                if (maxScreenMode == nil || mode.size.height > max.height || mode.size.width > max.width)
-                {
-                    max = mode.size
-                    maxScreenMode = mode
-                }
+                max = mode.size
+                maxScreenMode = mode
             }
         }
-        self.mirroredScreen?.currentMode = maxScreenMode
+        secondScreen.currentMode = maxScreenMode
         
-        // Setup window in external screen
-        if let mirroredScreen = mirroredScreen
-        {
-            self.mirroredWindow = UIWindow(frame: mirroredScreen.bounds)
-            self.mirroredWindow?.isHidden = false
-            self.mirroredWindow?.layer.contentsGravity = .resizeAspect
-            self.mirroredWindow?.screen = mirroredScreen
-        }
+        // setup window on second screen
+        self.airplayWindow = UIWindow(frame: secondScreen.bounds)
+        self.airplayWindow?.isHidden = false
+        self.airplayWindow?.layer.contentsGravity = .resizeAspect
+        self.airplayWindow?.screen = secondScreen
         
         self.gameView.removeFromSuperview()
         
-        self.mirroredWindow?.addSubview(self.gameView)
-        self.gameView.frame = mirroredWindow?.frame ?? .zero
+        self.airplayWindow?.addSubview(self.gameView)
+        self.gameView.frame = self.airplayWindow?.frame ?? .zero
         
         self.gameView.setNeedsLayout()
-        self.mirroredWindow?.layoutIfNeeded()
-    }
-    
-    func disableMirroring()
-    {
-        self.gameView.removeFromSuperview()
-        self.view.insertSubview(self.gameView, belowSubview: self.controllerView)
-        
-        self.mirroredScreen = nil
-        self.mirroredWindow = nil
-        
-        self.gameView.setNeedsLayout()
-        self.gameView.layoutIfNeeded()
-        self.view.setNeedsLayout()
-        self.view.layoutIfNeeded()
+        self.airplayWindow?.layoutIfNeeded()
     }
 }

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -259,16 +259,8 @@ open class GameViewController: UIViewController, GameControllerReceiver
             // Controller View Hidden:
             // - Controller View should have a height of 0.
             // - Game View should be centered in self.view.
-            
-            if let mirroredScreen = mirroredScreen
-            {
-                availableGameFrame = mirroredScreen.bounds
-                (controllerViewFrame, _) = self.view.bounds.divided(atDistance: 0, from: .maxYEdge)
-            }
-            else
-            {
-                (controllerViewFrame, availableGameFrame) = self.view.bounds.divided(atDistance: 0, from: .maxYEdge)
-            }
+             
+            (controllerViewFrame, availableGameFrame) = self.view.bounds.divided(atDistance: 0, from: .maxYEdge)
             
         case let traits? where traits.orientation == .portrait:
             // Portrait:
@@ -279,29 +271,12 @@ open class GameViewController: UIViewController, GameControllerReceiver
             if intrinsicContentSize.height != UIView.noIntrinsicMetric && intrinsicContentSize.width != UIView.noIntrinsicMetric
             {
                 let controllerViewHeight = (self.view.bounds.width / intrinsicContentSize.width) * intrinsicContentSize.height
-                
-                if let mirroredScreen = mirroredScreen
-                {
-                    availableGameFrame = mirroredScreen.bounds
-                    (controllerViewFrame, _) = self.view.bounds.divided(atDistance: controllerViewHeight, from: .maxYEdge)
-                }
-                else
-                {
-                    (controllerViewFrame, availableGameFrame) = self.view.bounds.divided(atDistance: controllerViewHeight, from: .maxYEdge)
-                }
+                (controllerViewFrame, availableGameFrame) = self.view.bounds.divided(atDistance: controllerViewHeight, from: .maxYEdge)
             }
             else
             {
                 controllerViewFrame = self.view.bounds
-                
-                if let mirroredScreen = mirroredScreen
-                {
-                    availableGameFrame = mirroredScreen.bounds
-                }
-                else
-                {
-                    availableGameFrame = self.view.bounds
-                }
+                availableGameFrame = self.view.bounds
             }
             
         case _?:
@@ -319,20 +294,14 @@ open class GameViewController: UIViewController, GameControllerReceiver
                 controllerViewFrame = self.view.bounds
             }
             
-            if let mirroredScreen = mirroredScreen
-            {
-                availableGameFrame = mirroredScreen.bounds
-            }
-            else
-            {
-                availableGameFrame = self.view.bounds
-            }
+            availableGameFrame = self.view.bounds
         }
         
         self.controllerView.frame = controllerViewFrame
         
         /* Game View */
         if
+            mirroredScreen == nil,
             let controllerSkin = self.controllerView.controllerSkin,
             let traits = self.controllerView.controllerSkinTraits,
             let screens = controllerSkin.screens(for: traits),
@@ -340,16 +309,13 @@ open class GameViewController: UIViewController, GameControllerReceiver
         {
             for (screen, gameView) in zip(screens, self.gameViews)
             {
-                if mirroredScreen == nil
-                {
-                    let outputFrame = screen.outputFrame.applying(.init(scaleX: self.view.bounds.width, y: self.view.bounds.height))
-                    gameView.frame = outputFrame
-                }
+                let outputFrame = screen.outputFrame.applying(.init(scaleX: self.view.bounds.width, y: self.view.bounds.height))
+                gameView.frame = outputFrame
             }
         }
         else
         {
-            let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatio, insideRect: availableGameFrame)
+            let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatio, insideRect: (mirroredScreen != nil) ? mirroredScreen!.bounds : availableGameFrame)
             self.gameView.frame = gameViewFrame
         }
         
@@ -435,16 +401,14 @@ extension GameViewController
                     gameView.filter = filterChain
                 }
                 
+                let outputFrame = screen.outputFrame.applying(.init(scaleX: self.view.bounds.width, y: self.view.bounds.height))
+                gameView.frame = outputFrame
+                
                 if let mirroredScreen = mirroredScreen
                 {
                     let screenAspectRatio = self.emulatorCore?.preferredRenderingSize ?? CGSize(width: 1, height: 1)
                     let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatio, insideRect: mirroredScreen.bounds)
                     self.gameView.frame = gameViewFrame
-                }
-                else
-                {
-                    let outputFrame = screen.outputFrame.applying(.init(scaleX: self.view.bounds.width, y: self.view.bounds.height))
-                    gameView.frame = outputFrame
                 }
                 
                 gameViews.append(gameView)

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -35,6 +35,9 @@ public protocol GameViewControllerDelegate: class
     func gameViewController(_ gameViewController: GameViewController, handleMenuInputFrom gameController: GameController)
     
     func gameViewControllerDidUpdate(_ gameViewController: GameViewController)
+    
+    func gameViewControllerDidEnterAirplay(_ gameViewController: GameViewController)
+    func gameViewControllerDidExitAirplay(_ gameViewController: GameViewController)
 }
 
 public extension GameViewControllerDelegate
@@ -45,6 +48,9 @@ public extension GameViewControllerDelegate
     func gameViewController(_ gameViewController: GameViewController, handleMenuInputFrom gameController: GameController) {}
     
     func gameViewControllerDidUpdate(_ gameViewController: GameViewController) {}
+    
+    func gameViewControllerDidEnterAirplay(_ gameViewController: GameViewController) {}
+    func gameViewControllerDidExitAirplay(_ gameViewController: GameViewController) {}
 }
 
 private var kvoContext = 0
@@ -645,7 +651,6 @@ public extension GameViewController
         // perform teardown first if already AirPlaying and screens are being switched
         if self.airplayWindow != nil
         {
-            self.gameView.removeFromSuperview()
             self.view.insertSubview(self.gameView, belowSubview: self.controllerView)
             
             self.airplayWindow = nil
@@ -654,6 +659,8 @@ public extension GameViewController
             self.gameView.layoutIfNeeded()
             self.view.setNeedsLayout()
             self.view.layoutIfNeeded()
+            
+            self.delegate?.gameViewControllerDidExitAirplay(self)
         }
         
         // now perform setup of AirPlay screen
@@ -683,12 +690,12 @@ public extension GameViewController
         self.airplayWindow?.layer.contentsGravity = .resizeAspect
         self.airplayWindow?.screen = secondScreen
         
-        self.gameView.removeFromSuperview()
-        
         self.airplayWindow?.addSubview(self.gameView)
         self.gameView.frame = self.airplayWindow?.frame ?? .zero
         
         self.gameView.setNeedsLayout()
         self.airplayWindow?.layoutIfNeeded()
+        
+        self.delegate?.gameViewControllerDidEnterAirplay(self)
     }
 }


### PR DESCRIPTION
This PR implements Optimized AirPlay Support as per [its Trello card.](https://trello.com/c/myn7Schk)

[There is a companion PR on Delta.](https://github.com/rileytestut/Delta/pull/119)

It's fully working and gets the feature just about there, minus a couple considerations noted below. Considerations are left unimplemented so as to keep this PR as small as possible.

Tested cases include:
- Default portrait and landscape skins on all current consoles (NES, SNES, GBC, GBA, N64, DS, GEN)
- Skins that act as overlays
- Skins that define a smaller, single screen (e.g. default landscape GBC)
- Rotation
- Entering/exiting mirroring
- External game controller attached/detached

Considerations:
- The sustain button view isn’t present on the mirrored screen, and no longer has the right constraints set once mirroring ends. Unsure if porting sustain over to the mirrored screen would be the right move to make or not
- When mirroring ends, I’m restoring `gameView` as a subview below `controllerView`. While that looked correct in my testing, it’s possible there is a more correct place elsewhere in the z-hierarchy that `gameView` should be that I have missed
- DS: currently this only mirrors the non-touch screen and leaves the touch screen on the iPhone screen. One day perhaps there could be a custom mirroring skin that allows for a larger touch screen when mirroring. That touches more code than I'm comfortable committing in this PR, so I leave that as an exercise for someone else 😉 

**NOTE:** refer to the [companion PR on Delta](https://github.com/rileytestut/Delta/pull/119) for the Settings toggle to enable the feature.

![IMG_1914](https://user-images.githubusercontent.com/18663382/139392907-1ace7cc2-4013-4504-b1c2-7130be8fd0db.PNG)

