### PR TITLE
Chore: add deadzone for handling for over-active x/y analog inputs

### DIFF
--- a/DeltaCore/Model/GameControllerStateManager.swift
+++ b/DeltaCore/Model/GameControllerStateManager.swift
@@ -60,11 +60,14 @@ extension GameControllerStateManager
     {
         precondition(input.type == .controller(self.gameController.inputType), "input.type must match self.gameController.inputType")
         
-        // Some external controllers' analog sticks report both x/y axis values incredibly granularly,
-        // hindering the ability to use the analog stick for only a single x/y axis value at a time.
-        // Solution: apply a higher deadzone to the analog sticks (currently the only continuous inputs)
-        // TODO: this could be a user-configurable threshold, but DeltaCore doesn't yet support configurable settings
-        guard !input.isContinuous || (input.isContinuous && value > 0.15) else { return }
+        if input.isContinuous
+        {
+            // Some external controllers' analog sticks report both x/y axis values incredibly granularly,
+            // hindering the ability to use the analog stick for only a single x/y axis value at a time.
+            // Solution: apply a higher deadzone to the analog sticks (currently the only continuous inputs)
+            // TODO: this could be a user-configurable threshold, but DeltaCore doesn't yet support configurable settings
+            guard value > 0.15 else { return }
+        }
         
         // An input may be "activated" multiple times, such as by pressing different buttons that map to same input, or moving an analog stick.
         self.activatedInputs[AnyInput(input)] = value

--- a/DeltaCore/Model/GameControllerStateManager.swift
+++ b/DeltaCore/Model/GameControllerStateManager.swift
@@ -60,7 +60,7 @@ extension GameControllerStateManager
     {
         precondition(input.type == .controller(self.gameController.inputType), "input.type must match self.gameController.inputType")
         
-        if input.isContinuous
+        if input.type == .controller(.mfi) && input.isContinuous
         {
             // Some external controllers' analog sticks report both x/y axis values incredibly granularly,
             // hindering the ability to use the analog stick for only a single x/y axis value at a time.

--- a/DeltaCore/Model/GameControllerStateManager.swift
+++ b/DeltaCore/Model/GameControllerStateManager.swift
@@ -60,6 +60,11 @@ extension GameControllerStateManager
     {
         precondition(input.type == .controller(self.gameController.inputType), "input.type must match self.gameController.inputType")
         
+        // Handle edge case where some physcial controllers' (like Xbox) analog sticks report both x/y inputs incredibly granularly,
+        // resulting in an inability to use the analog stick for only a single directional input at a time, such as in place of a d-pad.
+        // TODO: ideally this would be a user-configurable threshold, but DeltaCore doesn't currently support configurable settings.
+        guard !input.isContinuous || (input.isContinuous && value > 0.15) else { return }
+        
         // An input may be "activated" multiple times, such as by pressing different buttons that map to same input, or moving an analog stick.
         self.activatedInputs[AnyInput(input)] = value
         

--- a/DeltaCore/Model/GameControllerStateManager.swift
+++ b/DeltaCore/Model/GameControllerStateManager.swift
@@ -60,9 +60,10 @@ extension GameControllerStateManager
     {
         precondition(input.type == .controller(self.gameController.inputType), "input.type must match self.gameController.inputType")
         
-        // Handle edge case where some physcial controllers' (like Xbox) analog sticks report both x/y inputs incredibly granularly,
-        // resulting in an inability to use the analog stick for only a single directional input at a time, such as in place of a d-pad.
-        // TODO: ideally this would be a user-configurable threshold, but DeltaCore doesn't currently support configurable settings.
+        // Some external controllers' analog sticks report both x/y axis values incredibly granularly,
+        // hindering the ability to use the analog stick for only a single x/y axis value at a time.
+        // Solution: apply a higher deadzone to the analog sticks (currently the only continuous inputs)
+        // TODO: this could be a user-configurable threshold, but DeltaCore doesn't yet support configurable settings
         guard !input.isContinuous || (input.isContinuous && value > 0.15) else { return }
         
         // An input may be "activated" multiple times, such as by pressing different buttons that map to same input, or moving an analog stick.


### PR DESCRIPTION
Like the comment in the actual code says:

```
// Handle edge case where some physcial controllers' (like Xbox) analog sticks report both x/y inputs incredibly granularly,
// resulting in an inability to use the analog stick for only a single directional input at a time, such as in place of a d-pad.
// TODO: ideally this would be a user-configurable threshold, but DeltaCore doesn't currently support configurable settings.
```

This is similar to https://github.com/rileytestut/DeltaCore/pull/17 , although this implementation is 'deeper' in the controller call stack. For the controllers I tested with, the implementation in https://github.com/rileytestut/DeltaCore/pull/17 didn't work for every screen that handles game controller input -- such as the controller mapping screen -- whereas this implementation works system-wide.

This PR might also _not_ solve every use case that https://github.com/rileytestut/DeltaCore/pull/17 solves. Testing would be appreciated.