### PR TITLE
Use best available GL API

### DIFF
--- a/DeltaCore.xcodeproj/project.pbxproj
+++ b/DeltaCore.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9B6047D8283A4AAB00589F2E /* EAGLContext+BestAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6047D5283A496E00589F2E /* EAGLContext+BestAvailable.swift */; };
 		BF0B260B23E91745007BE38B /* Bundle+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0B260A23E91745007BE38B /* Bundle+Resources.swift */; };
 		BF0BC4FA225C138A000151C6 /* BitmapProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0BC4F9225C138A000151C6 /* BitmapProcessor.swift */; };
 		BF0BC4FD225C15E8000151C6 /* OpenGLESProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0BC4FC225C15E8000151C6 /* OpenGLESProcessor.swift */; };
@@ -97,6 +98,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9B6047D5283A496E00589F2E /* EAGLContext+BestAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EAGLContext+BestAvailable.swift"; sourceTree = "<group>"; };
 		BF0B260A23E91745007BE38B /* Bundle+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Resources.swift"; sourceTree = "<group>"; };
 		BF0BC4F9225C138A000151C6 /* BitmapProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapProcessor.swift; sourceTree = "<group>"; };
 		BF0BC4FC225C15E8000151C6 /* OpenGLESProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGLESProcessor.swift; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 				BFA5FCF320D3804300A3C5AB /* UIApplication+AppExtension.swift */,
 				BFA5FCF420D3804400A3C5AB /* UIResponder+FirstResponder.swift */,
 				BF0B260A23E91745007BE38B /* Bundle+Resources.swift */,
+				9B6047D5283A496E00589F2E /* EAGLContext+BestAvailable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -606,6 +609,7 @@
 				BFB8F0D41D186D6000D9CD05 /* Game.swift in Sources */,
 				BFEC24031D24CE7B00B3A6A9 /* RingBuffer.swift in Sources */,
 				BFBAE94520CC6E1A00E78FBC /* ExtensibleEnums.swift in Sources */,
+				9B6047D8283A4AAB00589F2E /* EAGLContext+BestAvailable.swift in Sources */,
 				BFEC23CD1D247E4A00B3A6A9 /* AudioRendering.swift in Sources */,
 				BF3273D51B86428200494CFC /* ExternalGameControllerManager.swift in Sources */,
 				BF78880D1C27F5AB0088084C /* UIImage+PDF.swift in Sources */,

--- a/DeltaCore/Emulator Core/Video/OpenGLESProcessor.swift
+++ b/DeltaCore/Emulator Core/Video/OpenGLESProcessor.swift
@@ -35,7 +35,7 @@ class OpenGLESProcessor: VideoProcessor
     init(videoFormat: VideoFormat, context: EAGLContext)
     {
         self.videoFormat = videoFormat
-        self.context = EAGLContext(api: .openGLES2, sharegroup: context.sharegroup)!
+        self.context = EAGLContext.createUsingBestAvailableAPI(sharegroup: context.sharegroup)
     }
     
     deinit

--- a/DeltaCore/Emulator Core/Video/VideoManager.swift
+++ b/DeltaCore/Emulator Core/Video/VideoManager.swift
@@ -65,7 +65,7 @@ public class VideoManager: NSObject, VideoRendering
     public init(videoFormat: VideoFormat)
     {
         self.videoFormat = videoFormat
-        self.context = EAGLContext(api: .openGLES2)!
+        self.context = EAGLContext.createUsingBestAvailableAPI()
         self.ciContext = CIContext(eaglContext: self.context, options: [.workingColorSpace: NSNull()])
         
         switch videoFormat.format

--- a/DeltaCore/Extensions/EAGLContext+BestAvailable.swift
+++ b/DeltaCore/Extensions/EAGLContext+BestAvailable.swift
@@ -1,0 +1,35 @@
+//
+//  EAGLContext+BestAvailable.swift
+//  DeltaCore
+//
+//  Created by David Chavez on 22.05.22.
+//  Copyright © 2022 Riley Testut. All rights reserved.
+//
+
+import GLKit
+
+extension EAGLContext {
+    static func createUsingBestAvailableAPI(sharegroup: EAGLSharegroup? = nil) -> EAGLContext {
+        if let sharegroup = sharegroup {
+            var context = EAGLContext(api: .openGLES3, sharegroup: sharegroup)
+            if context == nil {
+                context = EAGLContext(api: .openGLES2, sharegroup: sharegroup)
+                if context == nil {
+                    context = EAGLContext(api: .openGLES1, sharegroup: sharegroup)
+                }
+            }
+
+            return context!
+        }
+
+        var context = EAGLContext(api: .openGLES3)
+        if context == nil {
+            context = EAGLContext(api: .openGLES2)
+            if context == nil {
+                context = EAGLContext(api: .openGLES1)
+            }
+        }
+
+        return context!
+    }
+}

--- a/DeltaCore/UI/Game/GameView.swift
+++ b/DeltaCore/UI/Game/GameView.swift
@@ -90,7 +90,7 @@ public class GameView: UIView
             // to self.glkView may crash if we've already rendered to a game view.
             EAGLContext.setCurrent(nil)
             
-            self.glkView.context = EAGLContext(api: .openGLES2, sharegroup: newValue.sharegroup)!
+            self.glkView.context = EAGLContext.createUsingBestAvailableAPI(sharegroup: newValue.sharegroup)
             self.context = self.makeContext()
         }
     }
@@ -103,7 +103,7 @@ public class GameView: UIView
     
     public override init(frame: CGRect)
     {
-        let eaglContext = EAGLContext(api: .openGLES2)!
+        let eaglContext = EAGLContext.createUsingBestAvailableAPI()
         self.glkView = GLKView(frame: CGRect.zero, context: eaglContext)
         
         super.init(frame: frame)
@@ -113,7 +113,7 @@ public class GameView: UIView
     
     public required init?(coder aDecoder: NSCoder)
     {
-        let eaglContext = EAGLContext(api: .openGLES2)!
+        let eaglContext = EAGLContext.createUsingBestAvailableAPI()
         self.glkView = GLKView(frame: CGRect.zero, context: eaglContext)
         
         super.init(coder: aDecoder)


### PR DESCRIPTION
This change attempts to use the best available GL API for the device - allowing newer devices to use a better API. All around this should be an improvement but in Mupen64 (_currently only GL rendering core_) while playing Majora's mask some rendering artefacts are improved:

**OpenGL2**
![IMG_30848B9F3488-1](https://user-images.githubusercontent.com/2475932/169691905-db0f0fd6-f184-4deb-bfbd-52388f436838.jpeg)


**OpenGL3**
![IMG_0062](https://user-images.githubusercontent.com/2475932/169691839-9971ef36-ebfa-4b8d-bb15-7c28591c0441.PNG)

