### PR TITLE
[controller-inputs] fixes using analog sticks as discrete inputs on controllers with poor calibration

### DIFF
--- a/DeltaCore/Emulator Core/EmulatorCore.swift
+++ b/DeltaCore/Emulator Core/EmulatorCore.swift
@@ -361,6 +361,13 @@ extension EmulatorCore: GameControllerReceiver
         let discreteThreshold = 0.33
         var adjustedValue: Double? = value
         
+        if !input.isContinuous, controllerInput.isContinuous, value > (1.0 - discreteThreshold)
+        {
+            // input is discrete while controller input is continuous, so activate values greater than 0.66 for better responsiveness.
+            // this helps when using analog sticks as button inputs (especially for controllers with poor analog stick calibration).
+            adjustedValue = 1.0
+        }
+        
         if !input.isContinuous, value < discreteThreshold
         {
             // input is discrete, so ignore values less than 0.33 to avoid eagerly activating.


### PR DESCRIPTION
This PR fixes my experience with my Backbone One, and possibly other controllers. 

On my Backbone One's right Analog Stick, while the Y-Axis will report values up to 1.0, the X-Axis only reported up to 0.96 or so.

But because it's not the full 1.0 value, inputs coming from continuous inputs mapped to discrete ones (such as the right analog stick mapping to N64's c-buttons) would not fire at all.

Whether it's this code or a different fix, I would love a solution in Delta! 

(I do not know if this is the case with _all_ Backbone One controllers, or if mine is simply poorly calibrated, but it meant that my inputs weren't working regardless)