### PR TITLE
added `pixelPerfect` `samplerMode`

### DIFF
--- a/DeltaCore/UI/Game/GameView.swift
+++ b/DeltaCore/UI/Game/GameView.swift
@@ -126,6 +126,7 @@ public class GameView: UIView
     private var didLayoutSubviews = false
     private var didRenderInitialFrame = false
     private var isRenderingInitialFrame = false
+    private var pixelAlignmentOffset = CGPointZero
     
     private var isUsingMetal: Bool {
         let isUsingMetal = (self.eaglContext == nil)
@@ -155,7 +156,7 @@ public class GameView: UIView
     }
     
     private func initialize()
-    {        
+    {
         self.glkView.frame = self.bounds
         self.glkView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.glkView.delegate = self.glkViewDelegate
@@ -188,6 +189,8 @@ public class GameView: UIView
     public override func layoutSubviews()
     {
         super.layoutSubviews()
+        self.pixelAlignmentOffset.y = ceil(self.frame.minY) - self.frame.minY
+        self.pixelAlignmentOffset.x = ceil(self.frame.minX) - self.frame.minX
         
         if self.outputImage != nil
         {
@@ -363,6 +366,7 @@ private extension GameView
                 y = 0
             }
             let bounds = CGRect(x: x, y: y, width: width, height: height)
+            self.glkView.layer.frame.origin = pixelAlignmentOffset
             self.openGLESContext.draw(outputImage, in: bounds, from: outputImage.extent)
         }
     }
@@ -390,6 +394,7 @@ extension GameView: MTKViewDelegate
                 scaleY = floor(view.drawableSize.height / image.extent.height)
                 offsetX = floor((view.drawableSize.width - image.extent.width * scaleX) / 2)
                 offsetY = floor((view.drawableSize.height - image.extent.height * scaleY) / 2)
+                self.metalLayer?.frame.origin = self.pixelAlignmentOffset
             default:
                 scaleX = view.drawableSize.width / image.extent.width
                 scaleY = view.drawableSize.height / image.extent.height

--- a/DeltaCore/UI/Game/GameView.swift
+++ b/DeltaCore/UI/Game/GameView.swift
@@ -127,6 +127,7 @@ public class GameView: UIView
     private var didRenderInitialFrame = false
     private var isRenderingInitialFrame = false
     private var pixelAlignmentOffset = CGPointZero
+    private var lastGLKOffset = CGPointZero
     
     private var isUsingMetal: Bool {
         let isUsingMetal = (self.eaglContext == nil)
@@ -359,6 +360,12 @@ private extension GameView
                 height = floor(CGFloat(self.glkView.drawableHeight) / outputImage.extent.height) * outputImage.extent.height
                 x = floor((CGFloat(self.glkView.drawableWidth) - width) / 2)
                 y = floor((CGFloat(self.glkView.drawableHeight) - height) / 2)
+                if lastGLKOffset != pixelAlignmentOffset {
+                    DispatchQueue.main.async {
+                        self.glkView.frame.origin = self.pixelAlignmentOffset
+                        self.lastGLKOffset = self.glkView.frame.origin
+                    }
+                }
             default:
                 width = CGFloat(self.glkView.drawableWidth)
                 height = CGFloat(self.glkView.drawableHeight)
@@ -366,7 +373,6 @@ private extension GameView
                 y = 0
             }
             let bounds = CGRect(x: x, y: y, width: width, height: height)
-            self.glkView.layer.frame.origin = pixelAlignmentOffset
             self.openGLESContext.draw(outputImage, in: bounds, from: outputImage.extent)
         }
     }


### PR DESCRIPTION
I'm using Delta to test a GBA game I am working on.  I found that Delta by default uses `nearestNeighbor` scaling which results in some of the "pixels" being bigger than others.  This results in a "twinkling" effect when the background scrolls.  I found DeltaCore has an unused option for `linear` scaling that is more fair but blurry.

I added a `pixelPerfect` `samplerMode` option which uses the same nearest neighbor scaling on the `CIImage` level but changes the math for computing the scaling factor at the `openGL`/`Metal` level to choose the largest whole integer factor that fits within the given space.  This ensures each final rendered "pixel" contains the same number of hardware pixels on the iPhone screen, at the expense of some screen real estate.  This is more accurate, and, at least in my opinion, looks better.

Of course to actually activate the new sampling mode, a change in the main Delta app would be needed.  Honestly I'd recommend a user option to choose between the 3 sampling modes.
|`nearestNeighbor`|`linear`|`pixelPerfect`|
|-------------------|--------|-------------|
|![`nearestNeighbor`](https://github.com/user-attachments/assets/1113b5c9-c91c-43d6-9963-556d75bc530c)|![`linear`](https://github.com/user-attachments/assets/79bf804c-605e-4225-baf1-4ebad2647cad)|![`pixelPerfect`](https://github.com/user-attachments/assets/8dc9bf9e-d711-4008-bd9e-321a7ec2711a)|
|Pixels are not all the same shape, and are not all square.  Also some vertical blurring from a view alignment issue.|Evenly applied linear blur.|Slightly smaller but all pixels are exactly a square of 4x4 hardware pixels.|
|![zoom_nearest](https://github.com/user-attachments/assets/a1378586-69d8-4692-ab6f-49819bdbb05e)|![zoom_linear](https://github.com/user-attachments/assets/8a61af2d-3234-4645-b6f6-6af2db94ec40)|![zoom_pixelPerfect](https://github.com/user-attachments/assets/2e6d33e4-cb25-4f0d-a482-c92e9661882f)|
