### PR TITLE
Support Joystick Buttons L3 and R3

### DIFF
--- a/DeltaCore/Game Controllers/MFi/MFiGameController.swift
+++ b/DeltaCore/Game Controllers/MFi/MFiGameController.swift
@@ -44,12 +44,14 @@ extension MFiGameController
         case leftThumbstickDown
         case leftThumbstickLeft
         case leftThumbstickRight
-        
+        case leftThumbstickButton
+
         case rightThumbstickUp
         case rightThumbstickDown
         case rightThumbstickLeft
         case rightThumbstickRight
-        
+        case rightThumbstickButton
+
         case a
         case b
         case x
@@ -177,12 +179,15 @@ public class MFiGameController: NSObject, GameController
         profile.buttons[GCInputButtonB]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.b, pressed) }
         profile.buttons[GCInputButtonX]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.x, pressed) }
         profile.buttons[GCInputButtonY]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.y, pressed) }
-        
+
         profile.buttons[GCInputLeftShoulder]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.leftShoulder, pressed) }
         profile.buttons[GCInputLeftTrigger]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.leftTrigger, pressed) }
         profile.buttons[GCInputRightShoulder]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.rightShoulder, pressed) }
         profile.buttons[GCInputRightTrigger]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.rightTrigger, pressed) }
-        
+
+        profile.buttons[GCInputLeftThumbstickButton]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.leftThumbstickButton, pressed) }
+        profile.buttons[GCInputRightThumbstickButton]?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.rightThumbstickButton, pressed) }
+
         // Menu = Primary menu button (Start/+/Menu)
         let menuButton = profile.buttons[GCInputButtonMenu]
         menuButton?.pressedChangedHandler = { (button, value, pressed) in inputChangedHandler(.menu, pressed) }

--- a/DeltaCore/Model/Inputs/StandardGameControllerInput.swift
+++ b/DeltaCore/Model/Inputs/StandardGameControllerInput.swift
@@ -26,12 +26,14 @@ public enum StandardGameControllerInput: String, Codable
     case leftThumbstickDown
     case leftThumbstickLeft
     case leftThumbstickRight
-    
+    case leftThumbstickButton
+
     case rightThumbstickUp
     case rightThumbstickDown
     case rightThumbstickLeft
     case rightThumbstickRight
-    
+    case rightThumbstickButton
+
     case a
     case b
     case x

--- a/DeltaCore/Supporting Files/MFiGameController.deltamapping
+++ b/DeltaCore/Supporting Files/MFiGameController.deltamapping
@@ -41,6 +41,13 @@
 			<key>type</key>
 			<string>standard</string>
 		</dict>
+        <key>leftThumbstickButton</key>
+        <dict>
+            <key>identifier</key>
+            <string>l3</string>
+            <key>type</key>
+            <string>standard</string>
+        </dict>
 		<key>leftThumbstickDown</key>
 		<dict>
 			<key>identifier</key>
@@ -97,6 +104,13 @@
 			<key>type</key>
 			<string>standard</string>
 		</dict>
+        <key>rightThumbstickButton</key>
+        <dict>
+            <key>identifier</key>
+            <string>r3</string>
+            <key>type</key>
+            <string>standard</string>
+        </dict>
 		<key>rightThumbstickDown</key>
 		<dict>
 			<key>identifier</key>


### PR DESCRIPTION
(this PR obsoletes #45. That PR merged into an old branch, but I needed to open a new pull request to fix it)

Support clickable joystick buttons (L3 and R3) for MFI Controllers. I also added the enum and appropriate strings to `Extensions/Input+Display.swift` in a pull request for the main repository (will link in a comment, because that _also_ requires a new PR).

References issue #29 and implements some of PR #33 . `ExperimentalFeatures` only exists in the parent Delta repository, so there's no way to gate the actual value changed handlers behind a flag.